### PR TITLE
fix Espresso tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
         applicationId "fail.multidex.espresso"
 
 
-        minSdkVersion 16
+        minSdkVersion defaultMinSdkVersion
         targetSdkVersion defaultTargetSdkVersion
 
         testInstrumentationRunner "espresso.fail.multidex.CustomJunitRunner"

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 
 ext {
     defaultCompileSdkVersion = 25
-    defaultMinSdkVersion = 14
+    defaultMinSdkVersion = 18
     defaultTargetSdkVersion = 25
     defaultBuildToolsVersion = "25.0.2"
     defaultSupportLibVersion = "25.3.1"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -45,7 +45,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion defaultMinSdkVersion
         targetSdkVersion defaultTargetSdkVersion
 
         buildConfigField "String", "BUILD_REVISION", "\"${revision}\""
@@ -205,4 +205,10 @@ dependencies {
     compile 'com.fernandocejas.frodo:frodo-api:0.8.2'
     compile "com.android.support:support-v4:${defaultSupportLibVersion}"
     compile files('libs/omniture-4.6.1.jar')
+
+    androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+    androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
+
 }

--- a/pay/build.gradle
+++ b/pay/build.gradle
@@ -43,7 +43,7 @@ android {
 
     useLibrary 'org.apache.http.legacy'
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion defaultMinSdkVersion
         targetSdkVersion defaultTargetSdkVersion
 
         buildConfigField "String", "BUILD_REVISION", "\"${revision}\""


### PR DESCRIPTION
with this PR we can run 
```
./gradlew spoonGermanyDebugAndroidTest
```
to see our primary issue
```
:core:transformDexArchiveWithDexMergerForGermanyDebugAndroidTest
Dex: The number of method references in a .dex file cannot exceed 64K.
Learn how to resolve this issue at https://developer.android.com/tools/building/multidex.html
    UNEXPECTED TOP-LEVEL EXCEPTION:
    com.android.dex.DexIndexOverflowException: method ID not in [0, 0xffff]: 65536
    
com.android.dex.DexIndexOverflowException: method ID not in [0, 0xffff]: 65536
        at com.android.dx.merge.DexMerger$6.updateIndex(DexMerger.java:512)
        at com.android.dx.merge.DexMerger$IdMerger.mergeSorted(DexMerger.java:272)
        at com.android.dx.merge.DexMerger.mergeMethodIds(DexMerger.java:521)
        at com.android.dx.merge.DexMerger.mergeDexes(DexMerger.java:164)
        at com.android.dx.merge.DexMerger.merge(DexMerger.java:194)
        at com.android.builder.dexing.DexArchiveMergerCallable.mergeDexes(DexArchiveMergerCallable.java:67)
        at com.android.builder.dexing.DexArchiveMergerCallable.call(DexArchiveMergerCallable.java:54)
        at com.android.builder.dexing.DexArchiveMergerCallable.call(DexArchiveMergerCallable.java:37)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
:core:transformDexArchiveWithDexMergerForGermanyDebugAndroidTest FAILED

FAILURE: Build failed with an exception.
```